### PR TITLE
fixes install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,9 @@
-#sh
+#!/bin/bash
 
-git config --global alias.tree '!sh -c "'`pwd`'/bin/git-status-tree"'
+pushd `dirname $0` > /dev/null
+BIN_DIR=`pwd`
+popd > /dev/null
+
+git config --global alias.tree "!sh -c \"$BIN_DIR/git-status-tree\""
 echo 'git-status-tree successfully installed.'
 echo 'You can now use "git tree".'

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,4 +1,4 @@
-#sh
+#!/bin/bash
 
 git config --global --unset alias.tree
 echo 'git-status-tree successfully uninstalled.'


### PR DESCRIPTION
The current implementation fails when running the install script from inside `bin/`
