### PR TITLE
Handle deleted+untracked files

### DIFF
--- a/lib/node.rb
+++ b/lib/node.rb
@@ -109,7 +109,9 @@ class Node
       else
         color_name += BashColor::R
       end
-      color_name += name + ' (' + status + ')'
+      # status will be empty if a file is deleted+staged, then added (showing
+      # as deleted + unstaged). show '??' in that case.
+      color_name += name + ' (' + (status.length() > 0 ? status : '??') + ')'
     end
     color_name +=  BashColor::NONE
 


### PR DESCRIPTION
If a file is deleted, staged, then added back, we crash:

```bash
❯ git rm README.md
❯ echo "heyo" >> README.md
❯ ./bin/git-status-tree
Traceback (most recent call last):
        5: from /bin/git-status-tree:6:in `<main>'
        4: from /src/git_status_tree.rb:22:in `to_s'
        3: from /lib/node.rb:118:in `to_tree_s'
        2: from /lib/nodes_collection.rb:170:in `to_tree_s'
        1: from /lib/node.rb:112:in `to_tree_s'
/lib/node.rb:112:in `+': no implicit conversion of Array into String (TypeError)
```

Add a workaround. My ruby is extremely terrible but this at least
prevents crashing in this case 😬.

```bash
❯ ./bin/git-status-tree
.
├── lib
│   └── node.rb (M+)
└── README.md (??)
```

I don't know how to add test coverage for this 😞.